### PR TITLE
ReAdd removed identity change

### DIFF
--- a/sdk/identity/Azure.Identity.BrokeredAuthentication/api/Azure.Identity.BrokeredAuthentication.net462.cs
+++ b/sdk/identity/Azure.Identity.BrokeredAuthentication/api/Azure.Identity.BrokeredAuthentication.net462.cs
@@ -3,10 +3,12 @@ namespace Azure.Identity.BrokeredAuthentication
     public partial class InteractiveBrowserCredentialBrokerOptions : Azure.Identity.InteractiveBrowserCredentialOptions
     {
         public InteractiveBrowserCredentialBrokerOptions(System.IntPtr parentWindowHandle) { }
+        public bool? IsMsaPassthroughEnabled { get { throw null; } set { } }
     }
     public partial class SharedTokenCacheCredentialBrokerOptions : Azure.Identity.SharedTokenCacheCredentialOptions
     {
         public SharedTokenCacheCredentialBrokerOptions() { }
         public SharedTokenCacheCredentialBrokerOptions(Azure.Identity.TokenCachePersistenceOptions tokenCacheOptions) { }
+        public bool? IsMsaPassthroughEnabled { get { throw null; } set { } }
     }
 }


### PR DESCRIPTION
There is a change in my last [PR](https://github.com/hakimms/azure-sdk-for-net/pull/8) that was not intended to be a change. It was removing IsMsaPassthroughEnabled from Azure.Identity.BrokeredAuthentication.462.cs.

This change is showing up in my [PR ](https://github.com/Azure/azure-sdk-for-net/pull/38532/files#diff-4af8222faf1314f2b6b05fed157ce8a602d8113913e9425cf015e3d768430892) to azure/main from my fork